### PR TITLE
Add start script for Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,14 @@ You can pull and build the benchmark image from dockerhub with the following com
 
    2. Set environment variables in .env in root of project.
 
-   3. pull the benchmark image from dockerhub with:
+   3. Use the `start_benchmark.sh` script to pull the Docker image, start the container, and view logs interactively:
    ```
-    docker pull index.docker.io/akhilesh99/benchmark:latest
+   ./start_benchmark.sh
    ```
-   4. Run `docker compose up -d` to start the benchmark. This will start all of the services defined in the `compose.yaml` file.
 
-   ```
-      docker compose up -d 
-   ```
-   5. Run `docker compose logs -f questions`. This will print a Streamlit link to the benchmark dashboard to view progress.
+   4. Follow the interactive options provided by the script to pull the Docker image, start the container, and view logs.
 
-   6. To stop the benchmark, run `docker compose down`.
+   5. To stop the benchmark, run `docker compose down`.
 
 # Components
 

--- a/start_benchmark.sh
+++ b/start_benchmark.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Function to pull the Docker image
+pull_image() {
+    echo "Pulling Docker image..."
+    docker pull index.docker.io/akhilesh99/benchmark:latest
+}
+
+# Function to start the Docker container using docker-compose
+start_container() {
+    echo "Starting Docker container..."
+    docker-compose up -d
+}
+
+# Function to view logs interactively
+view_logs() {
+    echo "Viewing logs..."
+    docker-compose logs -f questions
+}
+
+# Main script logic
+echo "Select an option:"
+echo "1. Pull Docker image"
+echo "2. Start Docker container"
+echo "3. View logs"
+echo "4. Exit"
+
+read -p "Enter your choice [1-4]: " choice
+
+case $choice in
+    1)
+        pull_image
+        ;;
+    2)
+        start_container
+        ;;
+    3)
+        view_logs
+        ;;
+    4)
+        echo "Exiting..."
+        exit 0
+        ;;
+    *)
+        echo "Invalid choice. Exiting..."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Add a new script `start_benchmark.sh` to pull and start the Docker container with interactive options.

* **New Script: `start_benchmark.sh`**
  - Add a function to pull the Docker image.
  - Add a function to start the Docker container using `docker-compose`.
  - Add a function to view logs interactively.
  - Add a main script logic to provide interactive options for pulling the image, starting the container, viewing logs, and exiting.

* **Update `README.md`**
  - Update instructions to include the new `start_benchmark.sh` script.
  - Provide details on how to use the script for pulling and starting the Docker container.
  - Include information on viewing logs interactively.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vmanot/benchmark?shareId=d2e5e3d0-341b-4e6d-8abc-d66161bf5e50).